### PR TITLE
README: Fix link to locally-served documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository contains the documentation for Open Distro for Elasticsearch, a 
 
    `bundle exec jekyll serve`
 
-1. Open [http://localhost:4000](http://localhost:4000).
+1. Open [http://localhost:4000/for-elasticsearch-docs/](http://localhost:4000/for-elasticsearch-docs/).
 
 
 ## Contribute


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

When following the instructions from inside a ruby:latest container:

```
root@ad8bfa6165b9:/data# bundle exec jekyll serve
Configuration file: /data/_config.yml
            Source: /data
       Destination: /data/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
                    done in 8.085 seconds.
 Auto-regeneration: enabled for '/data'
    Server address: http://127.0.0.1:4000/for-elasticsearch-docs/
  Server running... press ctrl-c to stop.
```
Attempting to access / results in a HTTP 404.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
