### PR TITLE
Fix wrong yaml examples

### DIFF
--- a/docs/security-access-control/multi-tenancy.md
+++ b/docs/security-access-control/multi-tenancy.md
@@ -25,13 +25,13 @@ http://<kibana_host>:5601/app/kibana?security_tenant=analysts#/visualize/edit/c5
 Multi-tenancy is enabled by default, but you can disable it or change its settings using `plugins/opendistro_security/securityconfig/config.yml`:
 
 ```yml
-opendistro_security:
+config:
   dynamic:
     kibana:
       multitenancy_enabled: true
       server_username: kibanaserver
       index: '.kibana'
-      do_not_fail_on_forbidden: false
+    do_not_fail_on_forbidden: false
 ```
 
 Setting | Description


### PR DESCRIPTION
The current elasticsearch `config.yml` has slightly updated configs, see: https://github.com/opendistro-for-elasticsearch/security/blob/master/securityconfig/config.yml

*Description of changes:*
- main yaml key is now `config`
- `do_not_fail_on_forbidden` is not anymore under `kibana`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
