### PR TITLE
Added the notes about open distro ansible playbook 

### DIFF
--- a/docs/install/plugins.md
+++ b/docs/install/plugins.md
@@ -193,3 +193,6 @@ Elasticsearch doesn't update plugins. Instead, you have to remove and reinstall 
 sudo bin/elasticsearch-plugin remove <plugin-name>
 sudo bin/elasticsearch-plugin install <plugin-name>
 ```
+
+
+This [Ansible playbook](https://github.com/saravanan30erd/opendistro_standalone_installation) helps to install a Production Ready Open Distro Elasticsearch Cluster and Kibana using Standalone Plugin Installation method.{: .note }

--- a/docs/install/plugins.md
+++ b/docs/install/plugins.md
@@ -195,4 +195,5 @@ sudo bin/elasticsearch-plugin install <plugin-name>
 ```
 
 
-This [Ansible playbook](https://github.com/saravanan30erd/opendistro_standalone_installation) helps to install a Production Ready Open Distro Elasticsearch Cluster and Kibana using Standalone Plugin Installation method.{: .note }
+This [Ansible playbook](https://github.com/saravanan30erd/opendistro_standalone_installation) helps to install a Production Ready Open Distro Elasticsearch Cluster and Kibana using Standalone Plugin Installation method.
+{: .note }


### PR DESCRIPTION
*Description of changes:*

@aetter  To make Open Distro standalone plugin installation simple, wrote the ansible playbook which will install and configure Open distro elasticsearch and kibana using standalone method. It will help others to install Open distro standalone method in a easy way. I included the notes about the ansible playbook usage.

Open distro ansible playbook: https://github.com/saravanan30erd/opendistro_standalone_installation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
