### PR TITLE
Minimum RAM requirement

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -76,6 +76,7 @@ To stop the cluster and delete all data volumes, run:
 ```bash
 docker-compose down -v
 ```
+_Note: 8GB RAM/Memory is recommended for those using Docker Desktop, instead of the default 2GB setting._
 
 
 #### Sample Docker Compose file


### PR DESCRIPTION
When running `docker-compose up` it will take a very long time (or run out of memory) unless minimum RAM is increased in the Docker Desktop preferences
This was tested using a MacBook Pro.
Docker Desktop by default gives 2GB to Docker. I had to change Docker Desktop to give 8GB and then it worked as normal. With only 2GB, docker-compose would not bring up Kibana after waiting for about 10 minutes.

*Issue #, if available:*

*Description of changes:*
Change documentation to include minimum RAM

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
