### PR TITLE
Fix rollover condition.

### DIFF
--- a/docs/ism/policies.md
+++ b/docs/ism/policies.md
@@ -301,7 +301,7 @@ After 30 days, the policy moves this index into a `delete` state. The service se
         "actions": [
           {
             "rollover": {
-              "min_age": "1d"
+              "min_index_age": "1d"
             }
           }
         ],


### PR DESCRIPTION
Parameter **min_age** is invalid, it must be **min_index_age**.

https://opendistro.github.io/for-elasticsearch-docs/docs/ism/policies/#rollover

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
