### PR TITLE
Remove 'node.max_local_storage_nodes'.

### DIFF
--- a/docs/elasticsearch/configuration.md
+++ b/docs/elasticsearch/configuration.md
@@ -97,6 +97,5 @@ opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true
 opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
 cluster.routing.allocation.disk.threshold_enabled: false
-node.max_local_storage_nodes: 3
 ######## End OpenDistro for Elasticsearch Security Demo Configuration ########
 ```


### PR DESCRIPTION
"This setting is deprecated in 7.x and will be removed in version 8.0."

It seems that it's not recommended to permit more than 1 node to access to directory data on production clusters.

https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#max-local-storage-nodes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
