### PR TITLE
Remove redundant 'apt update'

### DIFF
--- a/docs/install/deb.md
+++ b/docs/install/deb.md
@@ -18,7 +18,6 @@ These steps assume you're using Ubuntu 18.04.
 
    ```bash
    sudo add-apt-repository ppa:openjdk-r/ppa
-   sudo apt update
    sudo apt install openjdk-11-jdk
    ```
 


### PR DESCRIPTION
The same command "add-apt-repository" does an "apt update" after add the repository.

```
$ sudo add-apt-repository ppa:openjdk-r/ppa

 More info: https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa
Press [ENTER] to continue or Ctrl-c to cancel adding it.

Hit:1 http://security.ubuntu.com/ubuntu bionic-security InRelease
Hit:2 http://ppa.launchpad.net/openjdk-r/ppa/ubuntu bionic InRelease
Hit:3 http://fr.archive.ubuntu.com/ubuntu bionic InRelease
Hit:4 http://fr.archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:5 http://fr.archive.ubuntu.com/ubuntu bionic-backports InRelease
Hit:6 https://d3g5vo6xdbdb9a.cloudfront.net/apt stable InRelease
Reading package lists... Done
$
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
