### PR TITLE
Full definition of S3 client settings.

### DIFF
--- a/docs/elasticsearch/snapshot-restore.md
+++ b/docs/elasticsearch/snapshot-restore.md
@@ -144,16 +144,16 @@ readonly | Whether the repository is read-only. Useful when migrating from one c
 1. (Optional) Add other settings to `elasticsearch.yml`:
 
    ```yml
-   disable_chunked_encoding: false # Disables chunked encoding for compatibility with some storage services, but you probably don't need to change this value.
-   endpoint: s3.amazonaws.com # S3 has alternate endpoints, but you probably don't need to change this value.
-   max_retries: 3 # number of retries if a request fails
-   path_style_access: false # whether to use the deprecated path-style bucket URLs.
+   s3.client.default.disable_chunked_encoding: false # Disables chunked encoding for compatibility with some storage services, but you probably don't need to change this value.
+   s3.client.default.endpoint: s3.amazonaws.com # S3 has alternate endpoints, but you probably don't need to change this value.
+   s3.client.default.max_retries: 3 # number of retries if a request fails
+   s3.client.default.path_style_access: false # whether to use the deprecated path-style bucket URLs.
    # You probably don't need to change this value, but for more information, see https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#path-style-access.
-   protocol: https # http or https
-   proxy.host: my-proxy-host # the hostname for your proxy server
-   proxy.port: 8080 # port for your proxy server
-   read_timeout: 50s # the S3 connection timeout
-   use_throttle_retries: true # whether the client should wait a progressively longer amount of time (exponential backoff) between each successive retry
+   s3.client.default.protocol: https # http or https
+   s3.client.default.proxy.host: my-proxy-host # the hostname for your proxy server
+   s3.client.default.proxy.port: 8080 # port for your proxy server
+   s3.client.default.read_timeout: 50s # the S3 connection timeout
+   s3.client.default.use_throttle_retries: true # whether the client should wait a progressively longer amount of time (exponential backoff) between each successive retry
    ```
 
 1. If you changed `elasticsearch.yml`, you must restart each node in the cluster. Otherwise, you only need to reload secure cluster settings:


### PR DESCRIPTION
With default doc options Elasticsearch does not start. For example editing "endpoint" parameter Elasticsearch gives this error:

```
[2020-04-18T11:45:54,211][ERROR][o.e.b.Bootstrap          ] [elasticsearch-node] Exception
java.lang.IllegalArgumentException: unknown setting [endpoint] please check that any required plugins are installed, or check the breaking changes documentation for removed settings
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:532) ~[elasticsearch-7.6.1.jar:7.6.1]
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:477) ~[elasticsearch-7.6.1.jar:7.6.1]
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:448) ~[elasticsearch-7.6.1.jar:7.6.1]
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:419) ~[elasticsearch-7.6.1.jar:7.6.1]
	at org.elasticsearch.common.settings.SettingsModule.<init>(SettingsModule.java:149) ~[elasticsearch-7.6.1.jar:7.6.1]
[...]
```

Reading official documentation says it must be in the following format:

```
s3.client.default.endpoint: my-storage.com
```

https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html#repository-s3-client

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
