### PR TITLE
Fixed the API doc for the GET actiongroups endpoint.

### DIFF
--- a/docs/security-access-control/api.md
+++ b/docs/security-access-control/api.md
@@ -173,7 +173,16 @@ GET _opendistro/_security/api/actiongroups/<action-group>
 
 ```json
 {
-  "SEARCH" : [ "indices:data/read/search*", "indices:data/read/msearch*", "SUGGEST" ]
+  "custom_action_group": {
+    "reserved": false,
+    "hidden": false,
+    "allowed_actions": [
+      "kibana_all_read",
+      "indices:admin/aliases/get",
+      "indices:admin/aliases/exists"
+    ],
+    "static": false
+  }
 }
 ```
 


### PR DESCRIPTION
In the API doc, changed the sample response of the get request for an action group :

It was previously documented like this:

```json
{
  "SEARCH" : [ "indices:data/read/search*", "indices:data/read/msearch*", "SUGGEST" ]
}
```

which I think is false, example request on this endpoint

$ curl https://localhost:9200/_opendistro/_security/api/actiongroups/custom_action_group?pretty
{
  "custom_action_group": {
    "reserved": false,
    "hidden": false,
    "allowed_actions": [
      "kibana_all_read",
      "indices:admin/aliases/get",
      "indices:admin/aliases/exists"
    ],
    "static": false
  }
}

As a result, I have changed the corresponding section to this :

```json
{
  "read": {
    "reserved": true,
    "hidden": false,
    "allowed_actions": [
      "indices:data/read*",
      "indices:admin/mappings/fields/get*"
    ],
    "type": "index",
    "description": "Allow all read operations",
    "static": true
  },
  ...
}
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
