### PR TITLE
Add LDAP Timeout Settings to Documentation

### DIFF
--- a/docs/security/configuration/ldap.md
+++ b/docs/security/configuration/ldap.md
@@ -101,6 +101,19 @@ config:
 You can configure more than one server here. If the security plugin cannot connect to the first server, it tries to connect to the remaining servers sequentially.
 
 
+### Timeouts
+
+To configure connection and response timeouts to your Active Directory server, use the following (values are expressed as milliseconds):
+
+```yml
+config:
+  connect_timeout: 5000
+  response_timeout: 0
+```
+
+If your server supports 2FA, the default timeout settings may result in some error during login. The `connect_timeout` can be increased to accommodate the 2FA process. Setting the `response_timeout` to 0 (the default) indicates an indefinite waiting period.
+
+
 ### Bind DN and password
 
 To configure the `bind_dn` and `password` that the security plugin uses when issuing queries to your server, use the following:


### PR DESCRIPTION
*Issue #:* https://github.com/opendistro-for-elasticsearch/security/issues/211

*Description of changes:* From the hidden configuration settings for LDAP authentication, the timeout settings should be made visible.

A recent run-in with an AD server that makes use of 2FA required a deep dive into the codebase.  The timeout settings were found, tested and works as expected, resulting in an acceptable timeframe to complete an AD login backed by a 2FA process.

The connection timeout affects the amount of time that is allowed to complete the 2FA process (at least in my case).  It's suggested to leave the response timeout at the default of 0 and adjust the connection timeout according to needs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
