### PR TITLE
Add ODFE Kibana 1.10.1 upgrade instructions to ODFE docs for breaking changes on cookies security settings

### DIFF
--- a/docs/upgrade/1-10-1.md
+++ b/docs/upgrade/1-10-1.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Upgrade to 1.10.1 (Kibana)
+parent: Upgrade
+nav_order: 3
+---
+
+# Upgrade to 1.10.1
+
+Open Distro for Elasticsearch 1.10.1 includes a breaking change due to Security Kibana Plugin is re-implemented on top of Kibana's new plugin platform.
+
+
+## Security Kibana Plugin
+
+If you:
+* Upgrade Kibana from any of the previous versions to 1.10.1
+* Use Security Kibana Plugin v1.10.1 and newer versions
+* Use **unsecured HTTP** as the communication protocol
+
+Then you need to add this line into your kibana.yml configuration file and restart Kibana
+```bash
+opendistro_security.cookie.secure: false
+```

--- a/docs/upgrade/1-10-1.md
+++ b/docs/upgrade/1-10-1.md
@@ -14,7 +14,7 @@ Open Distro for Elasticsearch 1.10.1 includes a breaking change due to Security 
 
 If you:
 * Upgrade Kibana from any of the previous versions to 1.10.1
-* Use Security Kibana Plugin v1.10.1 and newer versions
+* Use `Security Kibana Plugin` v1.10.1.1 and newer versions
 * Use **unsecured HTTP** as the communication protocol
 
 Then you need to add this line into your kibana.yml configuration file and restart Kibana

--- a/docs/upgrade/1-10-1.md
+++ b/docs/upgrade/1-10-1.md
@@ -7,7 +7,7 @@ nav_order: 3
 
 # Upgrade to 1.10.1 (Kibana)
 
-Open Distro for Elasticsearch 1.10.1 includes a breaking change due to the Security Kibana plugin being re-implemented with Kibana's new plugin platform
+Open Distro for Elasticsearch 1.10.1 includes a breaking change as Security Kibana plugin was re-implemented with Kibana’s new plugin platform
 
 ## Security Kibana Plugin
 

--- a/docs/upgrade/1-10-1.md
+++ b/docs/upgrade/1-10-1.md
@@ -7,14 +7,13 @@ nav_order: 3
 
 # Upgrade to 1.10.1 (Kibana)
 
-Open Distro for Elasticsearch 1.10.1 includes a breaking change due to Security Kibana Plugin is re-implemented on top of Kibana's new plugin platform.
-
+Open Distro for Elasticsearch 1.10.1 includes a breaking change due to the Security Kibana plugin being re-implemented with Kibana's new plugin platform
 
 ## Security Kibana Plugin
 
 If you:
 * Upgrade Kibana from any of the previous versions to 1.10.1
-* Use `Security Kibana Plugin` v1.10.1.1 and newer versions
+* Use `Security Kibana Plugin` v1.10.1.1 or newer
 * Use **unsecured HTTP** as the communication protocol
 
 Then you need to add this line into your kibana.yml configuration file and restart Kibana

--- a/docs/upgrade/1-10-1.md
+++ b/docs/upgrade/1-10-1.md
@@ -5,7 +5,7 @@ parent: Upgrade
 nav_order: 3
 ---
 
-# Upgrade to 1.10.1
+# Upgrade to 1.10.1 (Kibana)
 
 Open Distro for Elasticsearch 1.10.1 includes a breaking change due to Security Kibana Plugin is re-implemented on top of Kibana's new plugin platform.
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/418

*Description of changes:*
Add ODFE Kibana 1.10.1 upgrade instructions to ODFE docs for breaking changes on cookies security settings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
