### PR TITLE
Expand on sp.signature_private_key configuration usage

### DIFF
--- a/docs/security/configuration/saml.md
+++ b/docs/security/configuration/saml.md
@@ -154,7 +154,7 @@ Requests from the security plugin to the IdP can optionally be signed. Use the f
 
 Name | Description
 :--- | :---
-`sp.signature_private_key` | The private key used to sign the requests. Optional. Cannot be used when `private_key_filepath` is set.
+`sp.signature_private_key` | The private key used to sign the requests or to decode encrypted assertions. Optional. Cannot be used when `private_key_filepath` is set.
 `sp.signature_private_key_password` | The password of the private key, if any.
 `sp.signature_private_key_filepath` | Path to the private key. The file must be placed under the Open Distro for Elasticsearch `config` directory, and the path must be specified relative to that same directory.
 `sp.signature_algorithm` | The algorithm used to sign the requests. See the next table for possible values.


### PR DESCRIPTION
*Issue #, if available: See https://github.com/opendistro-for-elasticsearch/security/pull/539

*Description of changes:*
SAML config now supports encrypted assertions. Updating docs to reflect that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
