### PR TITLE
Added missing snapshot.all to rest-api-reference.md

### DIFF
--- a/docs/elasticsearch/rest-api-reference.md
+++ b/docs/elasticsearch/rest-api-reference.md
@@ -3342,13 +3342,26 @@ ccs_minimize_roundtrips | boolean | Indicates whether network round-trips should
 List all repositories.
 
 ```
+GET _snapshot/
+GET _snapshot/*
 GET _snapshot/_all
 ```
 
-List all  snapshots including detailed data in a repository.
+List all snapshots including detailed data in a repository.
 
 ```
+GET _snapshot/{repository}/*
 GET _snapshot/{repository}/_all
+```
+
+List snapshots based on a wildcard
+```
+GET _snapshot/{repository}/SomePrefix*
+```
+
+List currently running snapshots
+```
+GET _snapshot/{repository}/_current
 ```
 
 
@@ -3358,6 +3371,7 @@ Parameter | Type | Description
 :--- | :--- | :---
 master_timeout | time | Explicit operation timeout for connection to master node
 timeout | time | Explicit operation timeout
+verbose | bool | (only on snapshots) Adds metadata, start/end-time, errors etc. to response, defaults to true
 
 Further information about the returned fields etc. is available at https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshot-api.html
 

--- a/docs/elasticsearch/rest-api-reference.md
+++ b/docs/elasticsearch/rest-api-reference.md
@@ -3337,6 +3337,28 @@ rest_total_hits_as_int | boolean | Indicates whether hits.total should be render
 ccs_minimize_roundtrips | boolean | Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
 
 
+## snapshot.all
+
+List all repositories.
+
+```
+GET _snapshot/_all
+```
+
+List all  snapshots including detailed data in a repository.
+
+```
+GET _snapshot/{repository}/_all
+```
+
+
+#### URL parameters
+
+Parameter | Type | Description
+:--- | :--- | :---
+master_timeout | time | Explicit operation timeout for connection to master node
+timeout | time | Explicit operation timeout
+
 ## snapshot.cleanup_repository
 
 Removes stale data from repository.

--- a/docs/elasticsearch/rest-api-reference.md
+++ b/docs/elasticsearch/rest-api-reference.md
@@ -3359,6 +3359,8 @@ Parameter | Type | Description
 master_timeout | time | Explicit operation timeout for connection to master node
 timeout | time | Explicit operation timeout
 
+Further information about the returned fields etc. is available at https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshot-api.html
+
 ## snapshot.cleanup_repository
 
 Removes stale data from repository.


### PR DESCRIPTION

*Issue #, if available:*

<no issue as just documentation>

*Description of changes:*
Added missing documentation for Rest-APIs:
* _snapshot/_all 
*  _snapshot/{repo}/_all

Note: 
I assumed that the standard URL parameters are valid too (did not use them)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
