### PR TITLE
added curl translation for REST snippets

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -14,3 +14,5 @@ if(navigator.appVersion.indexOf('MSIE')>=0)document.write(unescape('%3C')+'\!-'+
 </noscript>
 <!--/DO NOT REMOVE/-->
 <!-- End SiteCatalyst code version: H.25.1. -->
+
+<script type="text/javascript" src="{{site.url}}{{site.baseurl}}/assets/js/curler.js"></script>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -216,3 +216,13 @@ h6 + p.label {
   padding-top: .25rem;
   padding-bottom: .25rem;
 }
+
+.snippet-control-bar {
+  text-align: right;
+}
+.snippet-control-bar .curl-rest-control {
+  cursor: pointer;
+}
+.snippet-control-bar .curl-rest-control.active {
+  font-weight: bold;
+}

--- a/assets/js/curler.js
+++ b/assets/js/curler.js
@@ -1,0 +1,76 @@
+
+  function RESTShorthandToCurl(el) {
+    var lines = el.textContent.split('\n');
+    var shorthand = /^(PUT|GET|POST|PATCH|DELETE)\s+(.+)/g.exec(lines[0]);
+    var out = [];
+    var curlOut = document.createElement('pre');
+    var curlCode = document.createElement('code');
+    var tabSelectors = {
+        divider : document.createElement('span'),
+        control : document.createElement('div'),
+        cURL : document.createElement('span'),
+        shorthand : document.createElement('span')
+    };
+    var tabActiveClass = 'active';
+    var tabNormalClass = 'curl-rest-control';
+    var tabPattern = [
+        ['none','block','remove','add'],
+        ['block','none','add','remove']
+    ];
+
+
+
+    if (shorthand) {
+        tabSelectors.control.classList.add('snippet-control-bar');
+        [tabSelectors.cURL,tabSelectors.shorthand].forEach(
+          function(controlEl) { controlEl.classList.add(tabNormalClass); }
+        );
+        curlOut.appendChild(curlCode);
+        curlOut.classList.add('highlight');
+        
+
+        tabSelectors.cURL.innerHTML = 'cURL';
+        tabSelectors.shorthand.innerHTML = 'REST';
+        tabSelectors.shorthand.classList.add(tabActiveClass);
+        tabSelectors.divider.innerHTML = ' &middot; ';
+        curlOut.style.display = 'none';
+
+
+
+        [tabSelectors.cURL, tabSelectors.shorthand].forEach(function(tabEl,index) {
+            tabEl.addEventListener('click', function () {
+                el.style.display = tabPattern[index][0];
+                curlOut.style.display = tabPattern[index][1];
+                tabSelectors.shorthand.classList[tabPattern[index][2]](tabActiveClass);
+                tabSelectors.cURL.classList[tabPattern[index][3]](tabActiveClass);
+            });
+        });
+       
+        out.push(
+            'curl \\',
+            '\t-H \'Content-Type: application/json\' \\',
+            '\t--user admin:admin -k \\',
+            '\t-X '+shorthand[1]+' "https://localhost:9200/'+shorthand[2]+'" \\'
+        );
+
+        if ((lines.slice(1).length > 0) && (lines.slice(1)[0].length > 0)) {
+            out.push('\t-d \''+lines.slice(1).join(' ')+'\'');
+        }
+        
+
+        curlCode.innerHTML = out.join('\r\n');
+
+        [tabSelectors.cURL, tabSelectors.divider, tabSelectors.shorthand].forEach(
+            function(el) { tabSelectors.control.appendChild(el); }
+        );
+
+        el.parentNode.appendChild(curlOut);
+        el.parentNode.appendChild(tabSelectors.control);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll(".highlight .highlight").forEach(function(el) {
+        RESTShorthandToCurl(el);
+    });
+});


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Added JS that will find REST Shorthand code examples and provide an automatic translation to cURL as needed.

<img width="764" alt="Screen Shot 2020-11-03 at 1 39 43 PM" src="https://user-images.githubusercontent.com/1152927/98038272-1659ec00-1dda-11eb-87aa-ed7841b819e0.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
