### PR TITLE
Fix Multi-Line SecurityAdmin Command Usage Example

### DIFF
--- a/docs/security/configuration/security-admin.md
+++ b/docs/security/configuration/security-admin.md
@@ -47,9 +47,9 @@ To print all available command line options, run the script with no arguments:
 To load configuration changes to the security plugin, you must provide your admin certificate to the tool:
 
 ```bash
-./securityadmin.sh -cd ../securityconfig/ -icl -nhnv  
-   -cacert ../../../config/root-ca.pem
-   -cert ../../../config/kirk.pem
+./securityadmin.sh -cd ../securityconfig/ -icl -nhnv \
+   -cacert ../../../config/root-ca.pem \
+   -cert ../../../config/kirk.pem \
    -key ../../../config/kirk-key.pem
 ```
 


### PR DESCRIPTION
Add backslash to fix multi-line command


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
