### PR TITLE
Document max_nested_depth in LDAP authz config

### DIFF
--- a/docs/security/configuration/ldap.md
+++ b/docs/security/configuration/ldap.md
@@ -498,6 +498,7 @@ Name | Description
 `userrolename`  | If the roles/groups of a user are not stored in the groups subtree, but as an attribute of the user's directory entry, define this attribute name here.
 `rolename`  | The attribute of the role entry that should be used as the role name.
 `resolve_nested_roles`  | Boolean. Whether or not to resolve nested roles. Default is `false`.
+`max_nested_depth`  | Integer. When `resolve_nested_roles` is `true`, this defines the maximum number of nested roles to traverse. Setting smaller values can reduce the amount of data retrieved from LDAP and improve authentication times at the cost of failing to discover deeply nested roles. Default is `30`.
 `skip_users`  | Array of users that should be skipped when retrieving roles. Wildcards and regular expressions are supported.
 `nested_role_filter`  | Array of role DNs that should be filtered before resolving nested roles. Wildcards and regular expressions are supported.
 `rolesearch_enabled`  | Boolean. Enable or disable the role search. Default is `true`.


### PR DESCRIPTION
Learned about the undocumented parameter `max_nested_depth` for LDAP authorization configuration from opendistro-for-elasticsearch/security#887

This PR documents this parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
