### PR TITLE
Fix typo in kibana-reports url endpoint

### DIFF
--- a/docs/kibana/plugins.md
+++ b/docs/kibana/plugins.md
@@ -137,7 +137,7 @@ This plugin lets you combine Kibana visualizations and narrative text in a singl
 #### Reports Kibana
 
 ```bash
-sudo bin/kibana-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/kibana-plugin/opendistro-reports/linux/x64/opendistroReportsKibana-{{site.odfe_version}}.0.zip
+sudo bin/kibana-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/kibana-plugins/opendistro-reports/linux/x64/opendistroReportsKibana-{{site.odfe_version}}.0.zip
 ```
 
 This plugin lets you export and share reports from Kibana dashboards, visualizations, and saved searches.


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/kibana-reports/issues/254

*Description of changes:* The endpoint is `kibana-plugins`, not `kibana-plugin`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
