### PR TITLE
Use main branch in link to helm chart

### DIFF
--- a/docs/install/helm.md
+++ b/docs/install/helm.md
@@ -20,7 +20,7 @@ Resource | Description
 The specification in the default Helm chart supports many standard use cases and setups. You can modify the default chart to configure your desired specifications and set Transport Layer Security (TLS) and role-based access control (RBAC).
 
 For information about the default configuration, steps to configure security, and configurable parameters, see the
-[README](https://github.com/opendistro-for-elasticsearch/community/tree/master/open-distro-elasticsearch-kubernetes/helm).
+[README](https://github.com/opendistro-for-elasticsearch/community/tree/main/open-distro-elasticsearch-kubernetes/helm).
 
 The instructions here assume you have a Kubernetes cluster with Helm preinstalled. See the [Kubernetes documentation](https://kubernetes.io/docs/setup/) for steps to configure a Kubernetes cluster and the [Helm documentation](https://helm.sh/docs/intro/install/) to install Helm.
 {: .note }


### PR DESCRIPTION
The page currently leads to the `master` branch which prompts you like this:

![Branch master was renamed to main.](https://user-images.githubusercontent.com/20454870/110480270-fb341b80-80ee-11eb-993e-d0a1cb9d1c0a.png)

So I changed it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
