### PR TITLE
Update multi-tenancy.md

### DIFF
--- a/docs/security/access-control/multi-tenancy.md
+++ b/docs/security/access-control/multi-tenancy.md
@@ -114,7 +114,7 @@ After creating a tenant, give a role access to it using Kibana, the REST API, or
 
 #### REST API
 
-See [Create role](../API/#create-role).
+See [Create role](../api/#create-role).
 
 
 #### roles.yml


### PR DESCRIPTION
Correcting `API` to `api` since `create roles` was actually pointing to https://opendistro.github.io/for-elasticsearch-docs/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
