### PR TITLE
improve code section look

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -50,8 +50,8 @@ code {
     margin-top: 2.4rem;
     margin-bottom: 0.8rem;
   }
-  pre.highlight {
-    line-height: normal;
+  .highlight {
+    line-height: 1.4;
   }
 }
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -23,7 +23,7 @@ body {
 }
 
 code {
-  font-family: "SFMono-Regular", Menlo, 'Droid Sans Mono', Consolas, Monospace;
+  font-family: "SFMono-Regular", Menlo, "DejaVu Sans Mono", "Droid Sans Mono", Consolas, Monospace;
   font-size: 0.75rem;
 }
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -23,6 +23,7 @@ body {
 }
 
 code {
+  font-family: "SFMono-Regular", Menlo, 'Droid Sans Mono', Consolas, Monospace;
   font-size: 0.75rem;
 }
 
@@ -48,6 +49,9 @@ code {
   h1, h2, h3, h4, h5, h6 {
     margin-top: 2.4rem;
     margin-bottom: 0.8rem;
+  }
+  pre.highlight {
+    line-height: normal;
   }
 }
 


### PR DESCRIPTION
*Description of changes:*
Default style from just-the-docs theme has a quite large line-height for code sections, and the font-family list only take macOS and Windows into consideration. On Linux ( RHEL 7 in my case ), Droid Sans Mono looks better.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
