### PR TITLE
Update helm.md

### DIFF
--- a/docs/install/helm.md
+++ b/docs/install/helm.md
@@ -20,7 +20,7 @@ Resource | Description
 The specification in the default Helm chart supports many standard use cases and setups. You can modify the default chart to configure your desired specifications and set Transport Layer Security (TLS) and role-based access control (RBAC).
 
 For information about the default configuration, steps to configure security, and configurable parameters, see the
-[README](https://github.com/opendistro-for-elasticsearch/community/tree/main/open-distro-elasticsearch-kubernetes/helm).
+[README](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/helm/README.md).
 
 The instructions here assume you have a Kubernetes cluster with Helm preinstalled. See the [Kubernetes documentation](https://kubernetes.io/docs/setup/) for steps to configure a Kubernetes cluster and the [Helm documentation](https://helm.sh/docs/intro/install/) to install Helm.
 {: .note }


### PR DESCRIPTION
README should link to `opendistro-build`

*Description of changes:*
Doc update to correct old link.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
