### PR TITLE
Update policies.md

### DIFF
--- a/docs/im/ism/policies.md
+++ b/docs/im/ism/policies.md
@@ -557,7 +557,7 @@ The following sample template policy is for a rollover use case.
 2. Set up a template with the `rollover_alias` as `log` :
 
    ```json
-   PUT _index_template/ism_rollover
+   PUT _template/ism_rollover
    {
      "index_patterns": ["log*"],
      "settings": {


### PR DESCRIPTION
Propose changing this endpoint to reflect this 2020 discussion to avoid the parse exception: https://discuss.opendistrocommunity.dev/t/error-in-indexmanagement/3674

*Description of changes:*
update the documented endpoint from `_index_template/ism_rollover` to `_template/rollover`. The former throws an `x_content_parse_exception`, the latter works.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
