### PR TITLE
Update Kibana Docker version

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -11,7 +11,7 @@ You can pull the Open Distro for Elasticsearch Docker image just like any other 
 
 ```bash
 docker pull amazon/opendistro-for-elasticsearch:{{site.odfe_version}}
-docker pull amazon/opendistro-for-elasticsearch-kibana:{{site.odfe_version}}
+docker pull amazon/opendistro-for-elasticsearch-kibana:latest
 ```
 
 To check available versions, see [Docker Hub](https://hub.docker.com/r/amazon/opendistro-for-elasticsearch/tags).
@@ -131,7 +131,7 @@ services:
     networks:
       - odfe-net
   kibana:
-    image: amazon/opendistro-for-elasticsearch-kibana:{{site.odfe_version}}
+    image: amazon/opendistro-for-elasticsearch-kibana:latest
     container_name: odfe-kibana
     ports:
       - 5601:5601


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/opendistro/for-elasticsearch-docs/issues/511

*Description of changes:*

Change Kibana Docker version to "latest" since we didn't publish a 1.13.3 version. Kibana didn't change because 1.13.3 only fixes the log4j stuff in the ES distribution, Kibana is written in Javascript so it isn't affected. See https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/793

@keithhc2 not sure if you prefer to put 1.13.2 here instead of latest, or whether you want to add any explanatory text around the version mismatch. Feel free to do either.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
